### PR TITLE
fix parseInt argument

### DIFF
--- a/src/components/AddBill.js
+++ b/src/components/AddBill.js
@@ -8,7 +8,10 @@ export default props => {
   const [date, setDate] = useState(new Date().toISOString())
 
   const handleChangeAmount = e => {
-    setAmount(parseInt(e.target.value, 10))
+    const value = parseInt(e.target.value, 10)
+    if (!Number.isNaN(value)) {
+      setAmount(value)
+    }
   }
 
   const handleChangeCategory = e => {

--- a/src/components/AddBill.js
+++ b/src/components/AddBill.js
@@ -8,7 +8,7 @@ export default props => {
   const [date, setDate] = useState(new Date().toISOString())
 
   const handleChangeAmount = e => {
-    setAmount(parseInt(e.target.value), 10)
+    setAmount(parseInt(e.target.value, 10))
   }
 
   const handleChangeCategory = e => {


### PR DESCRIPTION
Hi, during I'm studying your textbook, I found a tiny bug for `parseInt()` function arguments.

```
setAmount(parseInt(e.target.value), 10)
```

should be

```
setAmount(parseInt(e.target.value, 10))
```

Feel free to merge this PR :-) Thank you for the great textbook!